### PR TITLE
add support for to flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ var (
 	count     int
 	dryRun    bool
 	from      string
+	to        string
 	username  string
 	workers   int
 )
@@ -58,6 +59,8 @@ func main() {
 			"directory to store binaries")
 		cmd.Flags().StringVarP(
 			&from, "from", "f", "", "start date (YYYY-MM-DD) for backfill")
+		cmd.Flags().StringVarP(
+			&to, "to", "t", "", "end date (YYYY-MM-DD) for backfill")
 		cmd.Flags().BoolVarP(
 			&dryRun, "dry-run", "n", dryRun, "dry run (don't build binaries or run tests)")
 	}

--- a/run.go
+++ b/run.go
@@ -60,12 +60,19 @@ func runRun(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	if from != "" {
-		t, err := time.Parse("2006-01-02", from)
+	binaryPrefixFromTime := func(timeS string) string {
+		t, err := time.Parse("2006-01-02", timeS)
 		if err != nil {
 			log.Fatal(err)
 		}
-		from = "cockroach-" + t.Format("20060102") + "-"
+		return "cockroach-" + t.Format("20060102") + "-"
+	}
+
+	if from != "" {
+		from = binaryPrefixFromTime(from)
+	}
+	if to != "" {
+		to = binaryPrefixFromTime(to)
 	}
 
 	ch := make(chan string, workers)
@@ -89,6 +96,9 @@ func runRun(cmd *cobra.Command, args []string) {
 			base := filepath.Base(b)
 			if base < from {
 				continue
+			}
+			if to != "" && base > to {
+				break
 			}
 		}
 


### PR DESCRIPTION
Having the ability to control the end point for backfill is useful for filling holes. Also, the previous behavior would use the latest commit of the current day which may change throughout the day.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/petermattis/backfill/1)
<!-- Reviewable:end -->
